### PR TITLE
Use opentelemetry-spring-boot-starter

### DIFF
--- a/labs/unicorn-store/software/unicorn-store-spring/pom.xml
+++ b/labs/unicorn-store/software/unicorn-store-spring/pom.xml
@@ -38,6 +38,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+                <version>1.32.0-alpha</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -112,40 +119,19 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-instrumentation-annotations</artifactId>
-            <version>1.32.0</version>
+            <artifactId>opentelemetry-spring-boot-starter</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry.semconv</groupId>
-            <artifactId>opentelemetry-semconv</artifactId>
-            <version>1.23.1-alpha</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-aws-sdk-2.2 -->
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-aws-sdk-2.2</artifactId>
             <version>1.32.0-alpha</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/io.opentelemetry.contrib/opentelemetry-aws-xray -->
         <dependency>
             <groupId>io.opentelemetry.contrib</groupId>
             <artifactId>opentelemetry-aws-xray</artifactId>
             <version>1.32.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/io.opentelemetry.contrib/opentelemetry-aws-xray-propagator -->
         <dependency>
             <groupId>io.opentelemetry.contrib</groupId>
             <artifactId>opentelemetry-aws-xray-propagator</artifactId>


### PR DESCRIPTION
We didn't use the opentelemetry-spring-boot-starter so far but it simplifies the dependency management and also comes with auto configuration (see https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure).

I wonder if we can additionally simplify some of the stuff that has been done in https://github.com/aws-samples/java-on-aws/blob/main/labs/unicorn-store/software/unicorn-store-spring/src/main/java/com/unicorn/store/config/WebConfig.java.opt and https://github.com/aws-samples/java-on-aws/tree/main/labs/unicorn-store/software/unicorn-store-spring/src/main/java/com/unicorn/store/otel)?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
