### PR TITLE
Install the Session Manager plugin for the AWS CLI 

### DIFF
--- a/labs/unicorn-store/infrastructure/scripts/99-destroy-all.sh
+++ b/labs/unicorn-store/infrastructure/scripts/99-destroy-all.sh
@@ -103,6 +103,13 @@ aws codepipeline delete-pipeline --name unicorn-store-spring-deploy-ecs
 aws ecs delete-service --cluster unicorn-store-spring --service unicorn-store-spring --force 1> /dev/null
 aws ecs delete-cluster --cluster unicorn-store-spring 1> /dev/null
 
+##remove ec2 module resources
+export INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=*unicorn-store" --query "Reservations[*].Instances[*].InstanceId" --output text)
+aws ec2 terminate-instances --instance-ids $INSTANCE_ID
+
+aws codeartifact delete-repository --domain unicorn --repository unicorn
+aws codeartifact delete-domain --domain unicorn
+
 cdk destroy UnicornStoreInfrastructure --force
 cdk destroy UnicornStoreVpc --force
 

--- a/labs/unicorn-store/infrastructure/scripts/setup-ide.sh
+++ b/labs/unicorn-store/infrastructure/scripts/setup-ide.sh
@@ -146,3 +146,9 @@ aws configure get default.region
 test -n "$AWS_REGION" && echo AWS_REGION is "$AWS_REGION" || echo AWS_REGION is not set
 
 ~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/timeprint.sh "setup-ide" $start_time 2>&1 | tee >(cat >> /home/ec2-user/setup-timing.log)
+
+
+##  Download & install Session Manager plugin
+curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm" -o "session-manager-plugin.rpm"
+sudo yum install -y session-manager-plugin.rpm
+session-manager-plugin

--- a/labs/unicorn-store/infrastructure/scripts/setup-ide.sh
+++ b/labs/unicorn-store/infrastructure/scripts/setup-ide.sh
@@ -150,4 +150,5 @@ curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64b
 sudo yum install -y session-manager-plugin.rpm
 ## Test Session Manager plugin Installation
 session-manager-plugin
+rm session-manager-plugin.rpm
 ~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/timeprint.sh "setup-ide" $start_time 2>&1 | tee >(cat >> /home/ec2-user/setup-timing.log)

--- a/labs/unicorn-store/infrastructure/scripts/setup-ide.sh
+++ b/labs/unicorn-store/infrastructure/scripts/setup-ide.sh
@@ -145,10 +145,9 @@ aws configure set default.region ${AWS_REGION}
 aws configure get default.region
 test -n "$AWS_REGION" && echo AWS_REGION is "$AWS_REGION" || echo AWS_REGION is not set
 
-~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/timeprint.sh "setup-ide" $start_time 2>&1 | tee >(cat >> /home/ec2-user/setup-timing.log)
-
-
 ##  Download & install Session Manager plugin
 curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm" -o "session-manager-plugin.rpm"
 sudo yum install -y session-manager-plugin.rpm
+## Test Session Manager plugin Installation
 session-manager-plugin
+~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/timeprint.sh "setup-ide" $start_time 2>&1 | tee >(cat >> /home/ec2-user/setup-timing.log)

--- a/labs/unicorn-store/infrastructure/scripts/setup-infrastructure.sh
+++ b/labs/unicorn-store/infrastructure/scripts/setup-infrastructure.sh
@@ -71,4 +71,5 @@ source ~/.bashrc
 ~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/timeprint.sh "setup-vpc" $start_time 2>&1 | tee >(cat >> /home/ec2-user/setup-timing.log)
 
 ## Create Code Artifact repo
+aws codeartifact create-domain --domain unicorn
 aws codeartifact create-repository --domain unicorn --domain-owner $AWS_REGION --repository unicorn

--- a/labs/unicorn-store/infrastructure/scripts/setup-infrastructure.sh
+++ b/labs/unicorn-store/infrastructure/scripts/setup-infrastructure.sh
@@ -69,7 +69,3 @@ source ~/.bashrc
 ~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/setup-vpc-connector.sh
 ~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/setup-vpc-peering.sh
 ~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/timeprint.sh "setup-vpc" $start_time 2>&1 | tee >(cat >> /home/ec2-user/setup-timing.log)
-
-## Create Code Artifact repo
-aws codeartifact create-domain --domain unicorn
-aws codeartifact create-repository --domain unicorn --domain-owner $AWS_REGION --repository unicorn

--- a/labs/unicorn-store/infrastructure/scripts/setup-infrastructure.sh
+++ b/labs/unicorn-store/infrastructure/scripts/setup-infrastructure.sh
@@ -69,3 +69,6 @@ source ~/.bashrc
 ~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/setup-vpc-connector.sh
 ~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/setup-vpc-peering.sh
 ~/environment/java-on-aws/labs/unicorn-store/infrastructure/scripts/timeprint.sh "setup-vpc" $start_time 2>&1 | tee >(cat >> /home/ec2-user/setup-timing.log)
+
+## Create Code Artifact repo
+aws codeartifact create-repository --domain unicorn --domain-owner $AWS_REGION --repository unicorn


### PR DESCRIPTION
To showcase testing with aws ssm start-session as shown in video here[https://youtu.be/u3tgOE8qFjI?t=1763], installed Session Manager plugin for AWS CLI as per documentation here[https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-debian-and-ubuntu.html].


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
