### PR TITLE
fix enable manual otel script

### DIFF
--- a/labs/unicorn-store/software/scripts/enable-otel-manual.sh
+++ b/labs/unicorn-store/software/scripts/enable-otel-manual.sh
@@ -1,7 +1,6 @@
-
-
 cd ~/environment/unicorn-store-spring
 mv ./src/main/java/com/unicorn/store/otel/ApplicationFilter.java.opt ./src/main/java/com/unicorn/store/otel/ApplicationFilter.java
+mv ./src/main/java/com/unicorn/store/otel/TracingRequestInterceptor.java.opt ./src/main/java/com/unicorn/store/otel/TracingRequestInterceptor.java
 mv ./src/main/java/com/unicorn/store/otel/MetricEmitter.java.opt ./src/main/java/com/unicorn/store/otel/MetricEmitter.java
 mv ./src/main/java/com/unicorn/store/otel/PseudoRandomNumberGenerator.java.opt ./src/main/java/com/unicorn/store/otel/PseudoRandomNumberGenerator.java
 mv ./src/main/java/com/unicorn/store/otel/RandomNumberGenerator.java.opt ./src/main/java/com/unicorn/store/otel/RandomNumberGenerator.java


### PR DESCRIPTION
When testing otel manual instrumentation, one file was not converted to .java. This leads to compiling errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.