### PR TITLE
temp exclusion of json-path due to CVE-2023-51074

### DIFF
--- a/labs/unicorn-store/software/unicorn-store-spring/pom.xml
+++ b/labs/unicorn-store/software/unicorn-store-spring/pom.xml
@@ -93,6 +93,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion><!-- temp exclusion due to CVE-2023-51074 -->
+                    <groupId>com.jayway.jsonpath</groupId>
+                    <artifactId>json-path</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/java-on-aws/security/dependabot/13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
