### PR TITLE
move from GraalVM community to Mandrel 21-LTS

### DIFF
--- a/apps/dockerfiles/Dockerfile_05_GraalVM
+++ b/apps/dockerfiles/Dockerfile_05_GraalVM
@@ -1,7 +1,9 @@
-FROM ghcr.io/graalvm/graalvm-community:21 AS build-aot
+FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21 AS build-aot
 
+USER root
 RUN microdnf install -y unzip zip
 
+USER 1001
 RUN \
     curl -s "https://get.sdkman.io" | bash; \
     bash -c "source $HOME/.sdkman/bin/sdkman-init.sh; \
@@ -11,7 +13,6 @@ COPY ./pom.xml ./pom.xml
 COPY src ./src/
 
 ENV MAVEN_OPTS='-Xmx8g'
-
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && mvn -Dmaven.test.skip=true clean package -Pnative"
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
@@ -20,7 +21,7 @@ RUN yum install -y shadow-utils
 RUN groupadd --system spring -g 1000
 RUN adduser spring -u 1000 -g 1000
 
-COPY --from=build-aot /app/target/store-spring /
+COPY --from=build-aot /project/target/store-spring /
 
 USER 1000:1000
 

--- a/apps/unicorn-store-spring/pom.xml
+++ b/apps/unicorn-store-spring/pom.xml
@@ -177,7 +177,7 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
-                        <version>0.10.5-SNAPSHOT</version>
+                        <version>0.10.5</version>
                         <extensions>true</extensions>
                         <executions>
                             <execution>

--- a/apps/unicorn-store-spring/pom.xml
+++ b/apps/unicorn-store-spring/pom.xml
@@ -130,6 +130,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>graalvm-native-build-tools-snapshots</id>
+            <name>GraalVM native-build-tools Snapshots</name>
+            <url>https://raw.githubusercontent.com/graalvm/native-build-tools/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <profiles>
         <profile>
             <id>otel-manual</id>
@@ -162,12 +177,13 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
+                        <version>0.10.5-SNAPSHOT</version>
                         <extensions>true</extensions>
                         <executions>
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>
@@ -183,6 +199,7 @@
                             <metadataRepository>
                                 <enabled>true</enabled>
                             </metadataRepository>
+                            <requiredVersion>21</requiredVersion><!-- Spring Boot parent defines 22.3 -->
                             <buildArgs>
                                 <arg>--verbose</arg>
                                 <arg>


### PR DESCRIPTION
GraalVM CE is no longer receiving updates therefore moving to Mandrel which is using the repo with backports: https://github.com/graalvm/graalvm-community-jdk21u

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
