### PR TITLE
feat(apps): Migrate all apps to Spring AI 2.0 and Spring Boot 4.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+#
+# Grouping strategy: related dependencies that are released and upgraded
+# together are bundled into a single PR to cut review noise. Anything that
+# does not match a group still gets its own PR (Dependabot's default).
 
 version: 2
 updates:
@@ -10,16 +14,50 @@ updates:
       - "**/*"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 15
     groups:
+      # AWS SDK for Java artifacts are versioned in lockstep.
       awssdk:
         patterns:
           - "software.amazon.awssdk:*"
-    open-pull-requests-limit: 15
+      # Spring Boot, Spring Framework, Spring AI and the Spring-adjacent
+      # ecosystem move together on coordinated release trains. Bundling them
+      # keeps a Boot/Spring AI upgrade to a single reviewable PR per module.
+      spring:
+        patterns:
+          - "org.springframework:*"
+          - "org.springframework.*:*"
+          - "org.springaicommunity:*"
+          - "io.awspring.cloud:*"
+      # Build-time Maven plugins.
+      maven-plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "org.graalvm.buildtools:*"
+          - "io.spring.javaformat:*"
+          - "com.googlecode.maven-download-plugin:*"
+      # Test tooling.
+      testing:
+        patterns:
+          - "org.testcontainers:*"
+          - "*testcontainers*"
+          - "com.microsoft.playwright:*"
+      # Kubernetes Java client artifacts release together.
+      kubernetes:
+        patterns:
+          - "io.kubernetes:*"
   - package-ecosystem: docker
     directories:
       - "**/*"
     schedule:
       interval: "monthly"
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: pip
     directory: "/infra/scripts/setup/thread-dump-lambda"
     schedule:
@@ -37,3 +75,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/apps/ai-jvm-analyzer/pom.xml
+++ b/apps/ai-jvm-analyzer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
     <groupId>com.example.ai</groupId>
@@ -21,7 +21,7 @@
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-ai.version>1.1.7</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <dependencyManagement>

--- a/apps/ai-jvm-analyzer/src/main/java/com/example/ai/jvmanalyzer/GitHubSourceCodeTool.java
+++ b/apps/ai-jvm-analyzer/src/main/java/com/example/ai/jvmanalyzer/GitHubSourceCodeTool.java
@@ -1,6 +1,6 @@
 package com.example.ai.jvmanalyzer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;

--- a/apps/aiagent-agentcore/aiagent/pom.xml
+++ b/apps/aiagent-agentcore/aiagent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>com.example</groupId>
@@ -16,7 +16,7 @@
 
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>2.0.0-M6</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 	</properties>
 
 	<dependencies>
@@ -59,7 +59,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-advisors-vector-store</artifactId>
+			<artifactId>spring-ai-vector-store-advisor</artifactId>
 		</dependency>
 
 		<!-- Security - OAuth2 Resource Server for JWT validation -->

--- a/apps/aiagent-agentcore/backoffice/trip/pom.xml
+++ b/apps/aiagent-agentcore/backoffice/trip/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>com.example</groupId>

--- a/apps/aiagent/pom.xml
+++ b/apps/aiagent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>2.0.0-RC2</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/apps/java-spring-ai-agents/aiagent/pom.xml
+++ b/apps/java-spring-ai-agents/aiagent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/apps/java-spring-ai-agents/backoffice/tools/pom.xml
+++ b/apps/java-spring-ai-agents/backoffice/tools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>com.example</groupId>

--- a/apps/java-spring-ai-agents/backoffice/trip/pom.xml
+++ b/apps/java-spring-ai-agents/backoffice/trip/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>com.example</groupId>

--- a/apps/perf-analyzer/pom.xml
+++ b/apps/perf-analyzer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
 
@@ -19,7 +19,7 @@
         <java.version>25</java.version>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-ai.version>2.0.0-M6</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
         <aws-sdk.version>2.46.6</aws-sdk.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
     </properties>

--- a/apps/perf-collector/pom.xml
+++ b/apps/perf-collector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
 

--- a/apps/unicorn-spring-ai-agent/pom.xml
+++ b/apps/unicorn-spring-ai-agent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.unicorn</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>1.1.7</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 	</properties>
 	<dependencies>
 		<!-- Initial dependencies -->
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-advisors-vector-store</artifactId>
+            <artifactId>spring-ai-vector-store-advisor</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/apps/unicorn-store-spring/pom.xml
+++ b/apps/unicorn-store-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
     <groupId>com.unicorn</groupId>

--- a/samples/quality-assurance/ai-agent/pom.xml
+++ b/samples/quality-assurance/ai-agent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>2.0.0-M6</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 		<mcp-client-security.version>0.0.3</mcp-client-security.version>
 		<testcontainers.version>2.0.5</testcontainers.version>
 	</properties>

--- a/samples/quality-assurance/ai-agent/src/test/java/com/example/ai/agent/service/ChatClientEvaluatorTest.java
+++ b/samples/quality-assurance/ai-agent/src/test/java/com/example/ai/agent/service/ChatClientEvaluatorTest.java
@@ -54,7 +54,7 @@ public class ChatClientEvaluatorTest {
         OllamaApi ollamaApi = OllamaApi.builder().baseUrl(endpoint).build();
         evaluationModel = OllamaChatModel.builder()
                 .ollamaApi(ollamaApi)
-                .defaultOptions(OllamaChatOptions.builder()
+                .options(OllamaChatOptions.builder()
                         .model(EVALUATION_MODEL_ID)
                         .build())
                 .modelManagementOptions(ModelManagementOptions.builder()

--- a/samples/quality-assurance/weather/pom.xml
+++ b/samples/quality-assurance/weather/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>1.1.7</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/samples/quality-assurance/weather/src/main/java/com/example/weather/WeatherTools.java
+++ b/samples/quality-assurance/weather/src/main/java/com/example/weather/WeatherTools.java
@@ -2,7 +2,7 @@ package com.example.weather;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.stereotype.Component;
 
 /**

--- a/samples/quality-assurance/weather/src/test/java/com/example/weather/McpToolsIntegrationTest.java
+++ b/samples/quality-assurance/weather/src/test/java/com/example/weather/McpToolsIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.example.weather;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;

--- a/samples/security/apikey/ai-agent/pom.xml
+++ b/samples/security/apikey/ai-agent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>1.1.7</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 		<mcp-client-security.version>0.0.3</mcp-client-security.version>
 	</properties>
 	<repositories>

--- a/samples/security/apikey/weather/pom.xml
+++ b/samples/security/apikey/weather/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>1.1.7</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 		<mcp-security.version>0.1.12</mcp-security.version>
 	</properties>
 	<dependencyManagement>

--- a/samples/security/apikey/weather/src/main/java/com/example/weather/WeatherTools.java
+++ b/samples/security/apikey/weather/src/main/java/com/example/weather/WeatherTools.java
@@ -2,7 +2,7 @@ package com.example.weather;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 

--- a/samples/security/oauth/ai-agent/pom.xml
+++ b/samples/security/oauth/ai-agent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>1.1.7</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 		<mcp-client-security.version>0.1.12</mcp-client-security.version>
 	</properties>
 	<repositories>

--- a/samples/security/oauth/ai-agent/src/main/java/com/example/ai/agent/McpConfiguration.java
+++ b/samples/security/oauth/ai-agent/src/main/java/com/example/ai/agent/McpConfiguration.java
@@ -1,9 +1,10 @@
 package com.example.ai.agent;
 
+import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import org.springaicommunity.mcp.security.client.sync.AuthenticationMcpTransportContextProvider;
 import org.springaicommunity.mcp.security.client.sync.oauth2.http.client.OAuth2AuthorizationCodeSyncHttpRequestCustomizer;
-import org.springframework.ai.mcp.customizer.McpSyncClientCustomizer;
+import org.springframework.ai.mcp.customizer.McpClientCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
@@ -20,7 +21,7 @@ class McpConfiguration {
     }
 
     @Bean
-    McpSyncClientCustomizer syncClientCustomizer() {
+    McpClientCustomizer<McpClient.SyncSpec> syncClientCustomizer() {
         return (name, syncSpec) -> syncSpec.transportContextProvider(new AuthenticationMcpTransportContextProvider());
     }
 

--- a/samples/security/oauth/authorization-server/pom.xml
+++ b/samples/security/oauth/authorization-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
     <groupId>org.aws.samples</groupId>
@@ -14,7 +14,7 @@
     
     <properties>
         <java.version>25</java.version>
-        <spring-ai.version>1.1.7</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
         <mcp-security.version>0.1.12</mcp-security.version>
     </properties>
 

--- a/samples/security/oauth/weather/pom.xml
+++ b/samples/security/oauth/weather/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>1.1.7</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 		<mcp-security.version>0.1.12</mcp-security.version>
 	</properties>
 	<dependencyManagement>

--- a/samples/security/oauth/weather/src/main/java/com/example/weather/WeatherTools.java
+++ b/samples/security/oauth/weather/src/main/java/com/example/weather/WeatherTools.java
@@ -2,7 +2,7 @@ package com.example.weather;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 

--- a/samples/spring-ai-agent/pom.xml
+++ b/samples/spring-ai-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
     <groupId>com.aws.workshop.ai</groupId>
@@ -28,7 +28,7 @@
     </scm>
     <properties>
         <java.version>25</java.version>
-        <spring-ai.version>1.1.7</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
         <postgresql.version>42.7.11</postgresql.version>
         <jib-maven-plugin.version>3.4.5</jib-maven-plugin.version>
         <testcontainers.version>1.21.4</testcontainers.version>
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-advisors-vector-store</artifactId>
+            <artifactId>spring-ai-vector-store-advisor</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/samples/spring-ai-agent/src/main/java/com/aws/workshop/ai/agent/controller/ExternalizedMemoryAgentController.java
+++ b/samples/spring-ai-agent/src/main/java/com/aws/workshop/ai/agent/controller/ExternalizedMemoryAgentController.java
@@ -2,7 +2,7 @@ package com.aws.workshop.ai.agent.controller;
 
 import com.aws.workshop.ai.agent.memory.ExternalChatMemoryRepository;
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.PromptChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.prompt.ChatOptions;
@@ -14,7 +14,7 @@ import reactor.core.publisher.Flux;
 public class ExternalizedMemoryAgentController {
     private ChatClient chatClient;
     private final ChatClient.Builder chatClientBuilder;
-    private final PromptChatMemoryAdvisor promptChatMemoryAdvisor;
+    private final MessageChatMemoryAdvisor promptChatMemoryAdvisor;
 
     public ExternalizedMemoryAgentController(ChatClient chatClient, ChatClient.Builder chatClientBuilder, ExternalChatMemoryRepository externalChatMemoryRepository) {
         this.chatClient = chatClient;
@@ -22,7 +22,7 @@ public class ExternalizedMemoryAgentController {
         MessageWindowChatMemory chatMemory = MessageWindowChatMemory.builder()
                 .chatMemoryRepository(externalChatMemoryRepository)
                 .build();
-        this.promptChatMemoryAdvisor = PromptChatMemoryAdvisor.builder(chatMemory).build();
+        this.promptChatMemoryAdvisor = MessageChatMemoryAdvisor.builder(chatMemory).build();
     }
 
     @PostMapping("/chat")
@@ -49,9 +49,7 @@ public class ExternalizedMemoryAgentController {
 
     @PostMapping("/model")
     public void updateModel(@RequestParam String model) {
-        var chatOptions = ChatOptions.builder()
-                .model(model).build();
         chatClient = chatClientBuilder
-                .defaultOptions(chatOptions).build();
+                .defaultOptions(ChatOptions.builder().model(model)).build();
     }
 }

--- a/samples/spring-ai-agent/src/main/java/com/aws/workshop/ai/agent/controller/MemoryAgentController.java
+++ b/samples/spring-ai-agent/src/main/java/com/aws/workshop/ai/agent/controller/MemoryAgentController.java
@@ -1,7 +1,7 @@
 package com.aws.workshop.ai.agent.controller;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.PromptChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
@@ -14,7 +14,7 @@ import reactor.core.publisher.Flux;
 public class MemoryAgentController {
     private ChatClient chatClient;
     private final ChatClient.Builder chatClientBuilder;
-    private final PromptChatMemoryAdvisor promptChatMemoryAdvisor;
+    private final MessageChatMemoryAdvisor promptChatMemoryAdvisor;
 
     public MemoryAgentController(ChatClient chatClient, ChatClient.Builder chatClientBuilder) {
         this.chatClient = chatClient;
@@ -23,7 +23,7 @@ public class MemoryAgentController {
                 MessageWindowChatMemory.builder()
                         .chatMemoryRepository(new InMemoryChatMemoryRepository())
                         .build();
-        this.promptChatMemoryAdvisor = PromptChatMemoryAdvisor.builder(memory).build();
+        this.promptChatMemoryAdvisor = MessageChatMemoryAdvisor.builder(memory).build();
     }
 
     @PostMapping("/chat")
@@ -50,9 +50,7 @@ public class MemoryAgentController {
 
     @PostMapping("/model")
     public void updateModel(@RequestParam String model) {
-        var chatOptions = ChatOptions.builder()
-                .model(model).build();
         chatClient = chatClientBuilder
-                .defaultOptions(chatOptions).build();
+                .defaultOptions(ChatOptions.builder().model(model)).build();
     }
 }

--- a/samples/spring-ai-agent/src/main/java/com/aws/workshop/ai/agent/controller/RagPgVectorAgentController.java
+++ b/samples/spring-ai-agent/src/main/java/com/aws/workshop/ai/agent/controller/RagPgVectorAgentController.java
@@ -52,9 +52,7 @@ public class RagPgVectorAgentController {
 
     @PostMapping("/model")
     public void updateModel(@RequestParam String model) {
-        ChatOptions chatOptions = ChatOptions.builder()
-                .model(model).build();
         chatClient = chatClientBuilder
-                .defaultOptions(chatOptions).build();
+                .defaultOptions(ChatOptions.builder().model(model)).build();
     }
 }

--- a/samples/spring-ai-agent/src/main/java/com/aws/workshop/ai/agent/controller/StatelessAgentController.java
+++ b/samples/spring-ai-agent/src/main/java/com/aws/workshop/ai/agent/controller/StatelessAgentController.java
@@ -41,9 +41,7 @@ public class StatelessAgentController {
 
     @PostMapping("/model")
     public void updateModel(@RequestParam String model) {
-        var chatOptions = ChatOptions.builder()
-                .model(model).build();
         chatClient = chatClientBuilder
-                .defaultOptions(chatOptions).build();
+                .defaultOptions(ChatOptions.builder().model(model)).build();
     }
 }

--- a/samples/spring-ai-agent/src/test/java/com/aws/workshop/ai/agent/controller/ExternalizedMemoryAgentControllerTest.java
+++ b/samples/spring-ai-agent/src/test/java/com/aws/workshop/ai/agent/controller/ExternalizedMemoryAgentControllerTest.java
@@ -85,7 +85,7 @@ class ExternalizedMemoryAgentControllerTest {
         // Given
         String modelName = "test-model";
 
-        when(chatClientBuilder.defaultOptions(any(ChatOptions.class))).thenReturn(chatClientBuilder);
+        when(chatClientBuilder.defaultOptions(any(ChatOptions.Builder.class))).thenReturn(chatClientBuilder);
         when(chatClientBuilder.build()).thenReturn(chatClient);
 
         // When & Then
@@ -94,7 +94,7 @@ class ExternalizedMemoryAgentControllerTest {
                 .andExpect(status().isOk());
 
         verify(chatClientBuilder).defaultOptions(argThat(options ->
-                options.getModel() != null && options.getModel().equals(modelName)));
+                options.build().getModel() != null && options.build().getModel().equals(modelName)));
         verify(chatClientBuilder).build();
     }
 }

--- a/samples/spring-ai-agent/src/test/java/com/aws/workshop/ai/agent/controller/MemoryAgentControllerTest.java
+++ b/samples/spring-ai-agent/src/test/java/com/aws/workshop/ai/agent/controller/MemoryAgentControllerTest.java
@@ -84,7 +84,7 @@ class MemoryAgentControllerTest {
     void shouldUpdateModel() throws Exception {
         // Given
         String modelName = "test-model";
-        when(chatClientBuilder.defaultOptions(any(ChatOptions.class))).thenReturn(chatClientBuilder);
+        when(chatClientBuilder.defaultOptions(any(ChatOptions.Builder.class))).thenReturn(chatClientBuilder);
         when(chatClientBuilder.build()).thenReturn(chatClient);
 
         // When & Then
@@ -93,7 +93,7 @@ class MemoryAgentControllerTest {
                 .andExpect(status().isOk());
 
         verify(chatClientBuilder).defaultOptions(argThat(options ->
-                (options.getModel() != null) && options.getModel().equals(modelName)));
+                (options.build().getModel() != null) && options.build().getModel().equals(modelName)));
         verify(chatClientBuilder).build();
     }
 }

--- a/samples/spring-ai-simple-chat-client/pom.xml
+++ b/samples/spring-ai-simple-chat-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.unicorn</groupId>
@@ -15,7 +15,7 @@
 	<description>Simple Bedrock Chat Client for Spring AI</description>
 	<properties>
 		<java.version>25</java.version>
-		<spring-ai.version>1.1.7</spring-ai.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/samples/spring-cloud-function-demo/pom.xml
+++ b/samples/spring-cloud-function-demo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
     </parent>
     <groupId>com.amazonaws.demo</groupId>
     <artifactId>spring-cloud-function-demo</artifactId>


### PR DESCRIPTION
Upgrade every Maven module to Spring Boot 4.1.0 and consolidate all Spring AI usage on the 2.0.0 GA release (previously a mix of 1.1.7, 2.0.0-M6 and 2.0.0-RC2). Fix the breaking changes surfaced by the upgrade:

- Rename artifact spring-ai-advisors-vector-store to spring-ai-vector-store-advisor.
- Move @McpTool from org.springaicommunity.mcp.annotation to org.springframework.ai.mcp.annotation.
- Replace removed McpSyncClientCustomizer with the generic McpClientCustomizer<McpClient.SyncSpec>.
- Replace removed PromptChatMemoryAdvisor with MessageChatMemoryAdvisor.
- ChatClient.Builder.defaultOptions now takes a ChatOptions.Builder instead of a built ChatOptions; update call sites and tests.
- OllamaChatModel.Builder.defaultOptions renamed to options.
- Migrate direct Jackson databind usage to Jackson 3 (tools.jackson) where Spring AI 2.0 no longer brings Jackson 2 transitively.

All 23 modules compile (mvn clean test-compile) and the affected unit tests pass.

Also improve the Dependabot config: group Spring, Maven plugins, test tooling, Kubernetes, Docker images and GitHub Actions so coordinated upgrades arrive as single reviewable PRs instead of dozens.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
