### PR TITLE
fix(monitoring): Migrate Grafana Helm chart to grafana-community repo

### DIFF
--- a/infra/scripts/setup/monitoring.sh
+++ b/infra/scripts/setup/monitoring.sh
@@ -44,7 +44,7 @@ trap cleanup EXIT
 # Setup
 kubectl create namespace "$NAMESPACE" 2>/dev/null || true
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
-helm repo add grafana https://grafana.github.io/helm-charts || true
+helm repo add grafana-community https://grafana-community.github.io/helm-charts || true
 helm repo update
 
 # Grafana secret
@@ -152,7 +152,7 @@ grafana.ini:
 EOF
 
 log_info "Deploying Grafana..."
-helm upgrade --install grafana grafana/grafana \
+helm upgrade --install grafana grafana-community/grafana \
   --namespace "$NAMESPACE" \
   --values "$GRAFANA_VALUES_FILE"
 

--- a/infra/scripts/setup/perf-platform.sh
+++ b/infra/scripts/setup/perf-platform.sh
@@ -41,6 +41,7 @@ kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1 || {
 }
 
 helm repo add grafana https://grafana.github.io/helm-charts >/dev/null 2>&1 || true
+helm repo add grafana-community https://grafana-community.github.io/helm-charts >/dev/null 2>&1 || true
 helm repo update >/dev/null
 
 CLUSTER_NAME="${PREFIX}-eks"
@@ -288,7 +289,7 @@ GRAFANA_URL="http://${GRAFANA_LB}"
 
 # Install Profiles Drilldown plugin (idempotent).
 log_info "Installing Grafana Profiles Drilldown plugin..."
-helm upgrade --install grafana grafana/grafana \
+helm upgrade --install grafana grafana-community/grafana \
     --namespace "${NAMESPACE}" \
     --reuse-values \
     --set "plugins={grafana-pyroscope-app}" \


### PR DESCRIPTION
The grafana chart in grafana.github.io/helm-charts is now deprecated (frozen at chart 10.5.15 / Grafana 12.3.1, marked deprecated: true) after Grafana Labs forked the charts to grafana-community/helm-charts on March 16, 2026. Installs emit "WARNING: This chart is deprecated".

Point the grafana chart at the maintained community repo (grafana-community/grafana, chart 12.7.2 / Grafana 13.1.0) in both monitoring.sh and perf-platform.sh. All values keys used by the scripts (admin, service, persistence, resources, sidecar, plugins, grafana.ini) remain valid in the new chart.

The pyroscope chart was not moved, so perf-platform.sh keeps the original grafana repo alongside the new grafana-community repo for grafana/pyroscope.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
