### PR TITLE
fix(monitoring): Migrate Grafana to grafana-community chart and fix PVC deadlock

### DIFF
--- a/infra/scripts/setup/monitoring.sh
+++ b/infra/scripts/setup/monitoring.sh
@@ -116,6 +116,13 @@ persistence:
   storageClassName: gp3
   size: 10Gi
 
+# The PVC above is ReadWriteOnce (EBS). RollingUpdate (the chart default)
+# starts the new pod before the old one is deleted, so the new pod cannot
+# attach the volume still held by the old pod and the upgrade deadlocks.
+# Recreate terminates the old pod first, releasing the volume.
+deploymentStrategy:
+  type: Recreate
+
 resources:
   requests:
     cpu: 100m

--- a/infra/scripts/setup/monitoring.sh
+++ b/infra/scripts/setup/monitoring.sh
@@ -44,7 +44,7 @@ trap cleanup EXIT
 # Setup
 kubectl create namespace "$NAMESPACE" 2>/dev/null || true
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
-helm repo add grafana https://grafana.github.io/helm-charts || true
+helm repo add grafana-community https://grafana-community.github.io/helm-charts || true
 helm repo update
 
 # Grafana secret
@@ -152,7 +152,7 @@ grafana.ini:
 EOF
 
 log_info "Deploying Grafana..."
-helm upgrade --install grafana grafana/grafana \
+helm upgrade --install grafana grafana-community/grafana \
   --namespace "$NAMESPACE" \
   --values "$GRAFANA_VALUES_FILE"
 

--- a/infra/scripts/setup/perf-platform.sh
+++ b/infra/scripts/setup/perf-platform.sh
@@ -293,7 +293,7 @@ helm upgrade --install grafana grafana-community/grafana \
     --namespace "${NAMESPACE}" \
     --reuse-values \
     --set "plugins={grafana-pyroscope-app}" \
-    --wait --timeout 5m
+    --wait --timeout 10m
 log_success "Profiles Drilldown plugin installed"
 
 # Wait for Grafana API to be ready after the helm upgrade restarts the pod.

--- a/infra/scripts/setup/perf-platform.sh
+++ b/infra/scripts/setup/perf-platform.sh
@@ -41,6 +41,7 @@ kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1 || {
 }
 
 helm repo add grafana https://grafana.github.io/helm-charts >/dev/null 2>&1 || true
+helm repo add grafana-community https://grafana-community.github.io/helm-charts >/dev/null 2>&1 || true
 helm repo update >/dev/null
 
 CLUSTER_NAME="${PREFIX}-eks"
@@ -288,7 +289,7 @@ GRAFANA_URL="http://${GRAFANA_LB}"
 
 # Install Profiles Drilldown plugin (idempotent).
 log_info "Installing Grafana Profiles Drilldown plugin..."
-helm upgrade --install grafana grafana/grafana \
+helm upgrade --install grafana grafana-community/grafana \
     --namespace "${NAMESPACE}" \
     --reuse-values \
     --set "plugins={grafana-pyroscope-app}" \


### PR DESCRIPTION
## Summary

Fixes the workshop bootstrap failure in the performance-platform setup, where Grafana could not be installed/upgraded via Helm. Two independent root causes, both in the setup scripts (`infra/scripts/setup/monitoring.sh` and `infra/scripts/setup/perf-platform.sh`):

1. **Deprecated Helm chart.** As of March 16, 2026 Grafana Labs forked their Helm charts to `grafana-community/helm-charts`. The `grafana` chart in the old `grafana.github.io/helm-charts` repo is now `deprecated: true` and frozen at chart `10.5.15` (Grafana 12.3.1), so installs printed `WARNING: This chart is deprecated`.

2. **PVC deadlock on upgrade.** The chart defaults to `deploymentStrategy: RollingUpdate`, but the workshop enables persistence on a `gp3` EBS volume (ReadWriteOnce). On the plugin upgrade in `perf-platform.sh`, RollingUpdate starts the new pod before deleting the old one; the new pod cannot attach the RWO volume still held by the old pod, so it hangs until `helm --wait` hits its deadline: `UPGRADE FAILED: context deadline exceeded`.

## Changes

- Point the `grafana` chart at the maintained community repo `grafana-community/grafana` (chart `12.7.2` / Grafana `13.1.0`) in both scripts.
- Keep the original `grafana` repo in `perf-platform.sh` for `grafana/pyroscope`, which was **not** moved to the community repo.
- Set `deploymentStrategy.type: Recreate` in the Grafana values so the old pod is torn down first and releases the EBS volume. Persisted on the release, so `perf-platform.sh` inherits it via `--reuse-values`.
- Raise the plugin-install `--timeout` from `5m` to `10m` to cover the EBS detach/reattach cycle plus plugin download on the Recreate path.

## Verification

- Confirmed the old `grafana` chart is `deprecated: true` and the community repo serves an active `grafana` chart (`12.7.2`).
- Confirmed `pyroscope` still resolves only from the old repo.
- Confirmed every values key the scripts pass (`admin.existingSecret/userKey/passwordKey`, `service`, `persistence`, `resources`, `sidecar.dashboards/datasources`, `plugins`, `grafana.ini`) exists in the community `12.7.2` chart.
- `bash -n` passes on both scripts. CI green (the one flaky failure was a transient Maven Central 403 on `spring-boot-starter-parent:4.1.0`, unrelated to these changes; cleared on re-run).
