### PR TITLE
fix(monitoring): Pin Grafana 12.3.1 + pyroscope-app 1.17.0 for HTTP

### DIFF
--- a/infra/scripts/setup/monitoring.sh
+++ b/infra/scripts/setup/monitoring.sh
@@ -100,6 +100,15 @@ trap - EXIT
 
 # Grafana values
 cat > "$GRAFANA_VALUES_FILE" <<EOF
+# Pin Grafana to 12.x (React 18). Grafana 13 moved to React 19, which breaks
+# the grafana-pyroscope-app 1.x plugin (it reads a React 18 internal removed
+# in React 19). We must stay on the 1.x plugin because the 2.x line calls
+# crypto.randomUUID(), unavailable over plain HTTP (the workshop serves
+# Grafana over HTTP, not a browser secure context). Grafana 12.x + plugin
+# 1.17.0 is the combination that loads over HTTP.
+image:
+  tag: "12.3.1"
+
 admin:
   existingSecret: grafana-admin
   userKey: username

--- a/infra/scripts/setup/perf-platform.sh
+++ b/infra/scripts/setup/perf-platform.sh
@@ -289,10 +289,17 @@ GRAFANA_URL="http://${GRAFANA_LB}"
 
 # Install Profiles Drilldown plugin (idempotent).
 log_info "Installing Grafana Profiles Drilldown plugin..."
+# Pin grafana-pyroscope-app to 1.17.0. The workshop serves Grafana over plain
+# HTTP (not a browser secure context), and the 2.x plugin line calls
+# crypto.randomUUID() at load, which browsers only expose over HTTPS/localhost,
+# so 2.x fails with "crypto.randomUUID is not a function". 1.17.0 is the last
+# release whose entry bundle avoids that call. It targets React 18, so it
+# requires Grafana 12.x (see the image.tag pin in monitoring.sh); Grafana 13
+# ships React 19 and breaks the 1.x plugin.
 helm upgrade --install grafana grafana-community/grafana \
     --namespace "${NAMESPACE}" \
     --reuse-values \
-    --set "plugins={grafana-pyroscope-app}" \
+    --set "plugins={grafana-pyroscope-app@1.17.0}" \
     --wait --timeout 10m
 log_success "Profiles Drilldown plugin installed"
 


### PR DESCRIPTION
The workshop serves Grafana over plain HTTP (LoadBalancer, http://<lb>), which is not a browser secure context. That constrains the Profiles Drilldown plugin (grafana-pyroscope-app) as follows:

- 2.x calls crypto.randomUUID() at load; browsers only expose it over HTTPS/localhost, so it throws "crypto.randomUUID is not a function".
- 1.17.0 avoids that call but targets React 18, so it needs Grafana 12.x. On Grafana 13 (React 19) it fails with a ReactCurrentOwner TypeError, because it reads a React 18 internal removed in React 19.

The only combination that loads over HTTP is Grafana 12.x + plugin 1.x. Pin the Grafana image to 12.3.1 (React 18, the version the previous deprecated chart shipped) and the plugin to grafana-pyroscope-app@1.17.0.

Use the id@version plugin syntax; Grafana's background installer misreads the older space-separated "id version" form as a second plugin id.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
